### PR TITLE
feat: add get_order_form_abandoned_carts to query checkout order forms via …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
 # Changelog
 
-## 0.9.0 (2026-07-16)
+## 0.9.0 (2026-07-28)
 - Add get_order_form_abandoned_carts to query checkout_silver.order_form_consolidated via DQAPI
-- Return abandoned carts for profiles who never submitted an order (1 row per profile)
-- Support optional sales_channel filter (defaults to channel 1 in the metric)
 
 ## 0.8.0 (2026-04-29)
 - Add new methods to get unique and recurring contacts in Datalake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.9.0 (2026-07-16)
+- Add get_order_form_abandoned_carts to query checkout_silver.order_form_consolidated via DQAPI
+- Return abandoned carts for profiles who never submitted an order (1 row per profile)
+- Support optional sales_channel filter (defaults to channel 1 in the metric)
+
 ## 0.8.0 (2026-04-29)
 - Add new methods to get unique and recurring contacts in Datalake
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ REDSHIFT_ROLE_ARN=your_role_arn
 MESSAGE_TEMPLATES_METRIC_NAME=your_metric_name (if you want to get message templates)
 TRACES_METRIC_NAME=your_trace_metric_name (if you want to get traces)
 EVENTS_METRIC_NAME=your_event_metric_name (if you want to get events)
+ORDER_FORM_ABANDONED_CARTS_METRIC_NAME=your_metric_name (if you want to get order form abandoned carts)
 ```
 
 Although you will need some AWS credentials to get data from the data lake, you can use the following environment variables:
@@ -261,6 +262,33 @@ Don't forget to set in your enviroment the following variables to get silver dat
 EVENTS_SILVER_METRIC_NAME
 EVENTS_SILVER_COUNT_METRIC_NAME
 EVENTS_SILVER_COUNT_BY_GROUP_METRIC_NAME
+
+### 10. Get Order Form Abandoned Carts
+
+```python
+from weni_datalake_sdk.clients.redshift.order_form import get_order_form_abandoned_carts
+
+# Get abandoned carts from profiles who never submitted an order
+result = get_order_form_abandoned_carts(
+    account_name="superangeloni", # account_name is required
+    dt_start="2026-04-01 00:00:00", # dt_start is required
+    dt_end="2026-07-13 00:00:00", # dt_end is required
+    sales_channel="1", # sales_channel is optional (defaults to channel 1 in the metric)
+)
+print(result)
+```
+
+The response follows the DQAPI envelope and returns one row per profile in `values`:
+
+```python
+rows = result["values"]
+for row in rows:
+    print(row["profile_id"], row["last_total_value"], row["funnel_score"])
+```
+
+Don't forget to set in your enviroment the following variable:
+
+ORDER_FORM_ABANDONED_CARTS_METRIC_NAME
 
 ## Error Handling
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 packages = [{ include = "weni_datalake_sdk" }]
 name = "weni-datalake-sdk"
-version = "0.8.0"
+version = "0.9.0"
 description = "Lib to connect python/django modules to redshift"
 authors = ["Lucas Linhares <lucas.linhares@vtex.com>"]
 license = "MIT"

--- a/weni_datalake_sdk/clients/redshift/order_form.py
+++ b/weni_datalake_sdk/clients/redshift/order_form.py
@@ -1,0 +1,39 @@
+import os
+from typing import Optional
+
+from weni_datalake_sdk.clients.redshift.redshift_client import query_dc_api
+
+
+def get_order_form_abandoned_carts(
+    account_name: str,
+    dt_start: str,
+    dt_end: str,
+    sales_channel: Optional[str] = None,
+) -> dict:
+    metric = os.environ.get("ORDER_FORM_ABANDONED_CARTS_METRIC_NAME")
+
+    if not account_name:
+        raise Exception("Account name is required")
+
+    if not dt_start:
+        raise Exception("Date start is required")
+
+    if not dt_end:
+        raise Exception("Date end is required")
+
+    query_params = {
+        "account_name": account_name,
+        "dt_start": dt_start,
+        "dt_end": dt_end,
+    }
+
+    if sales_channel:
+        query_params["sales_channel"] = sales_channel
+
+    try:
+        result = query_dc_api(metric=metric, query_params=query_params)
+        data = result.json()
+        return data
+
+    except Exception as e:
+        raise Exception(f"Error querying order form abandoned carts: {e}")

--- a/weni_datalake_sdk/tests/test_order_form.py
+++ b/weni_datalake_sdk/tests/test_order_form.py
@@ -47,7 +47,9 @@ class TestGetOrderFormAbandonedCarts:
             )
             assert result[0]["profile_id"] == "profile-123"
 
-    def test_get_order_form_abandoned_carts_without_sales_channel(self, mock_env_metric):
+    def test_get_order_form_abandoned_carts_without_sales_channel(
+        self, mock_env_metric
+    ):
         with mock.patch(
             "weni_datalake_sdk.clients.redshift.order_form.query_dc_api"
         ) as mock_query:

--- a/weni_datalake_sdk/tests/test_order_form.py
+++ b/weni_datalake_sdk/tests/test_order_form.py
@@ -1,0 +1,119 @@
+from unittest import mock
+
+import pytest
+
+from weni_datalake_sdk.clients.redshift.order_form import (
+    get_order_form_abandoned_carts,
+)
+
+
+class TestGetOrderFormAbandonedCarts:
+    @pytest.fixture
+    def mock_env_metric(self, monkeypatch):
+        monkeypatch.setenv(
+            "ORDER_FORM_ABANDONED_CARTS_METRIC_NAME",
+            "test_metric_order_form_abandoned_carts",
+        )
+
+    def test_get_order_form_abandoned_carts_success(self, mock_env_metric):
+        with mock.patch(
+            "weni_datalake_sdk.clients.redshift.order_form.query_dc_api"
+        ) as mock_query:
+            mock_response = mock.Mock()
+            mock_response.json.return_value = [
+                {
+                    "profile_id": "profile-123",
+                    "order_form_id": "of-456",
+                    "last_total_value": 150.0,
+                }
+            ]
+            mock_query.return_value = mock_response
+
+            result = get_order_form_abandoned_carts(
+                account_name="superangeloni",
+                dt_start="2026-04-01 00:00:00",
+                dt_end="2026-07-13 00:00:00",
+                sales_channel="1",
+            )
+
+            mock_query.assert_called_once_with(
+                metric="test_metric_order_form_abandoned_carts",
+                query_params={
+                    "account_name": "superangeloni",
+                    "dt_start": "2026-04-01 00:00:00",
+                    "dt_end": "2026-07-13 00:00:00",
+                    "sales_channel": "1",
+                },
+            )
+            assert result[0]["profile_id"] == "profile-123"
+
+    def test_get_order_form_abandoned_carts_without_sales_channel(self, mock_env_metric):
+        with mock.patch(
+            "weni_datalake_sdk.clients.redshift.order_form.query_dc_api"
+        ) as mock_query:
+            mock_response = mock.Mock()
+            mock_response.json.return_value = []
+            mock_query.return_value = mock_response
+
+            result = get_order_form_abandoned_carts(
+                account_name="superangeloni",
+                dt_start="2026-04-01 00:00:00",
+                dt_end="2026-07-13 00:00:00",
+            )
+
+            mock_query.assert_called_once_with(
+                metric="test_metric_order_form_abandoned_carts",
+                query_params={
+                    "account_name": "superangeloni",
+                    "dt_start": "2026-04-01 00:00:00",
+                    "dt_end": "2026-07-13 00:00:00",
+                },
+            )
+            assert result == []
+
+    def test_get_order_form_abandoned_carts_missing_account_name(self, mock_env_metric):
+        with pytest.raises(Exception) as exc_info:
+            get_order_form_abandoned_carts(
+                account_name="",
+                dt_start="2026-04-01 00:00:00",
+                dt_end="2026-07-13 00:00:00",
+            )
+
+        assert "Account name is required" in str(exc_info.value)
+
+    def test_get_order_form_abandoned_carts_missing_dt_start(self, mock_env_metric):
+        with pytest.raises(Exception) as exc_info:
+            get_order_form_abandoned_carts(
+                account_name="superangeloni",
+                dt_start="",
+                dt_end="2026-07-13 00:00:00",
+            )
+
+        assert "Date start is required" in str(exc_info.value)
+
+    def test_get_order_form_abandoned_carts_missing_dt_end(self, mock_env_metric):
+        with pytest.raises(Exception) as exc_info:
+            get_order_form_abandoned_carts(
+                account_name="superangeloni",
+                dt_start="2026-04-01 00:00:00",
+                dt_end="",
+            )
+
+        assert "Date end is required" in str(exc_info.value)
+
+    def test_get_order_form_abandoned_carts_api_error(self, mock_env_metric):
+        with mock.patch(
+            "weni_datalake_sdk.clients.redshift.order_form.query_dc_api"
+        ) as mock_query:
+            mock_query.side_effect = Exception("API Error")
+
+            with pytest.raises(Exception) as exc_info:
+                get_order_form_abandoned_carts(
+                    account_name="superangeloni",
+                    dt_start="2026-04-01 00:00:00",
+                    dt_end="2026-07-13 00:00:00",
+                )
+
+            assert "Error querying order form abandoned carts: API Error" in str(
+                exc_info.value
+            )


### PR DESCRIPTION
…DQAPI.

Expose abandoned cart profiles from checkout_silver.order_form_consolidated with optional sales_channel filter, bump version to 0.9.0.